### PR TITLE
tests: use assertEqual instead of assertEquals

### DIFF
--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -12,8 +12,8 @@ class TestScoresResource(app.AppTestCase):
             }
         )
 
-        self.assertEquals(req.status_code, 201)
-        self.assertEquals(req.json.get('id'), 1)
+        self.assertEqual(req.status_code, 201)
+        self.assertEqual(req.json.get('id'), 1)
 
     def test_can_list(self):
         post_req = self.app.post_json(
@@ -24,10 +24,10 @@ class TestScoresResource(app.AppTestCase):
                 'score': 50
             }
         )
-        self.assertEquals(post_req.status_code, 201)
+        self.assertEqual(post_req.status_code, 201)
 
         get_req = self.app.get('/scores')
-        self.assertEquals(get_req.status_code, 200)
+        self.assertEqual(get_req.status_code, 200)
 
         score_list = get_req.json.get('scores')
-        self.assertEquals(len(score_list), 1)
+        self.assertEqual(len(score_list), 1)


### PR DESCRIPTION
Fixes:
DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(req.status_code, 201)