### PR TITLE
 Making database and gunicorn configs required

### DIFF
--- a/example/config.py
+++ b/example/config.py
@@ -3,7 +3,7 @@ from aumbry import Attr, YamlConfig
 
 class DatabaseConfig(YamlConfig):
     __mapping__ = {
-        'connection': Attr('connection', str),
+        'connection': Attr('connection', str, required=True),
     }
 
     connection = ''
@@ -11,7 +11,7 @@ class DatabaseConfig(YamlConfig):
 
 class AppConfig(YamlConfig):
     __mapping__ = {
-        'db': Attr('db', DatabaseConfig),
+        'db': Attr('db', DatabaseConfig, required=True),
         'gunicorn': Attr('gunicorn', dict),
     }
 

--- a/example/config.py
+++ b/example/config.py
@@ -12,7 +12,7 @@ class DatabaseConfig(YamlConfig):
 class AppConfig(YamlConfig):
     __mapping__ = {
         'db': Attr('db', DatabaseConfig, required=True),
-        'gunicorn': Attr('gunicorn', dict),
+        'gunicorn': Attr('gunicorn', dict, required=True),
     }
 
     def __init__(self):


### PR DESCRIPTION
For this example database and gunicorn configs are required and should pass presence check. By adding `required=True` we perform this check and make it explicit. 